### PR TITLE
Fixed wrong collision height used in IsWithinLOSInMap

### DIFF
--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -1246,7 +1246,7 @@ bool WorldObject::IsWithinLOSInMap(WorldObject const* obj, LineOfSightChecks che
     if (GetTypeId() == TYPEID_PLAYER)
     {
         GetPosition(x, y, z);
-        z += GetCollisionHeight();
+        z += obj->GetCollisionHeight();
     }
     else
         GetHitSpherePointFor({ obj->GetPositionX(), obj->GetPositionY(), obj->GetPositionZ() + obj->GetCollisionHeight() }, x, y, z);


### PR DESCRIPTION
**Changes proposed:**

Fixed an oversight leading to calculation using the current object collision height instead of the target one.
Shouldn't have effect in most cases as the collision height don't vary much.  
But the intent in this function is clearly to calculate to ending point of the LoS check and it should use the target collision height. Also the GetHitSpherePointFor just under does use it correctly, making it obvious it's just an oversight.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** 
/
Had to fix it when trying to fix resurrection of released players (but this fix alone won't be enough for it).

**Tests performed:** (Does it build, tested in-game, etc.)
Used on live server then ptr for ~10 months
https://github.com/kelno/sunstrider/commit/0c08dfe7f6
